### PR TITLE
Fix a reflection warning

### DIFF
--- a/src/spell_spec/alpha.cljc
+++ b/src/spell_spec/alpha.cljc
@@ -57,7 +57,7 @@
       dist)))
 
 (defn- similar-key [ky ky2]
-  (let [min-len (apply min (map (comp count #(if (.startsWith % ":") (subs % 1) %) str) [ky ky2]))]
+  (let [min-len (apply min (map (comp count #(if (.startsWith ^String % ":") (subs % 1) %) str) [ky ky2]))]
     (similar-key* (#?(:clj *length->threshold*
                       :cljs length->threshold)
                    min-len) ky ky2)))


### PR DESCRIPTION
Running `lein check` gives the following warning:

```
Reflection warning, spell_spec/alpha.cljc:60:50 - call to method startsWith can't be resolved (target class is unknown).
```